### PR TITLE
chore: report workflow failure for artifacts

### DIFF
--- a/.github/workflows/artifact_check.yml
+++ b/.github/workflows/artifact_check.yml
@@ -137,3 +137,9 @@ jobs:
           curl -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
           -d "{\"tag_name\": \"$latest_release_tag\", \"name\": \"$RELEASE_NAME\", \"body\": \"$BODY\"}" \
           "https://api.github.com/repos/${{ github.repository }}/releases"
+
+  report_failure:
+    needs: pull_latest_artifacts
+    if: ${{ failure() }}
+    uses: sourcegraph/workflows/.github/workflows/report-job-failure.yml@main
+    secrets: inherit


### PR DESCRIPTION
Ensure when a workflow fails, it notifies the dev-infra team.