### PR TITLE
chore: validate latest release tag during check 

### DIFF
--- a/.github/workflows/artifact_check.yml
+++ b/.github/workflows/artifact_check.yml
@@ -23,6 +23,10 @@ jobs:
         id: get_latest_release
         run: |
           LATEST_RELEASE=$(curl --fail -s -H "Authorization: Bearer ${{ secrets.PRIVATE_SG_ACCESS_TOKEN }}" https://api.github.com/repos/sourcegraph/sourcegraph/releases/latest | jq -r .tag_name)
+          if [ -z "$LATEST_RELEASE" ]; then
+            echo "unable the fetch releases from github"
+            exit 1
+          fi
           echo "latest_release=${LATEST_RELEASE}" >> $GITHUB_OUTPUT
 
       - name: Read TAG file


### PR DESCRIPTION
## Test Plan

This adds a check in the workflow to check that we're able to get the latest release from GitHub's API. The check currently fails because the API is inaccessible and `LATEST_RELEASE` is an empty string.